### PR TITLE
Make MSVC happy with specialized Pow

### DIFF
--- a/src/pbrt/util/math.h
+++ b/src/pbrt/util/math.h
@@ -295,6 +295,7 @@ PBRT_CPU_GPU inline Float Pow(Float base, Float exp) {
 }
 #else
     PBRT_CPU_GPU inline constexpr Float Pow(Float base, Float exp) {
+        return std::pow(base, exp);
 }
 #endif
 

--- a/src/pbrt/util/math.h
+++ b/src/pbrt/util/math.h
@@ -289,9 +289,14 @@ PBRT_CPU_GPU inline constexpr T Sqr(T v) {
     return v * v;
 }
 
-PBRT_CPU_GPU inline constexpr Float Pow(Float base, Float exp) {
-    return std::pow(base, exp);
+#ifdef PBRT_IS_MSVC
+PBRT_CPU_GPU inline Float Pow(Float base, Float exp) {
+    return std::powf(base, exp);
 }
+#else
+    PBRT_CPU_GPU inline constexpr Float Pow(Float base, Float exp) {
+}
+#endif
 
 // Would be nice to allow Float to be a template type here, but it is tricky:
 // https://stackoverflow.com/questions/5101516/why-function-template-cannot-be-partially-specialized


### PR DESCRIPTION
Here, MSVC 2022 return a error with  the constexpr for Pow while Clang compiles sucessful